### PR TITLE
Adding completion command.

### DIFF
--- a/pkg/commands/completion.go
+++ b/pkg/commands/completion.go
@@ -1,0 +1,32 @@
+package commands
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	addCompletion(rootCmd)
+}
+
+func addCompletion(topLevel *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "completion",
+		Short: "Generates bash completion scripts",
+		Long: `To load completion run
+
+. <(hue-cli completion)
+
+To configure your bash shell to load completions for each session add to your bashrc
+
+# ~/.bashrc or ~/.profile
+. <(hue-cli completion)
+`,
+		Run: func(cmd *cobra.Command, args []string) {
+			_ = topLevel.GenBashCompletion(os.Stdout)
+		},
+	}
+
+	topLevel.AddCommand(cmd)
+}

--- a/pkg/commands/options/identifiers.go
+++ b/pkg/commands/options/identifiers.go
@@ -7,9 +7,12 @@ import (
 // IDOptions
 type IDOptions struct {
 	ID     int
+	Name string
 }
 
 func AddIDArgs(cmd *cobra.Command, o *IDOptions) {
 	cmd.Flags().IntVar(&o.ID, "id", 0,
-		"The ID.")
+		"The id.")
+	cmd.Flags().StringVar(&o.Name, "name", "",
+		"The name.")
 }

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -20,9 +20,6 @@ var (
 		Use:   "hue-cli",
 		Short: "hue-cli is a CLI tool for philips hue ecosystem",
 		Long:  `TODO`,
-		Run: func(cmd *cobra.Command, args []string) {
-			// display help
-		},
 	}
 )
 


### PR DESCRIPTION
Adding bash completion support.

```
(╯°□°)╯︵  hue-cli completion --help
To load completion run

. <(hue-cli completion)

To configure your bash shell to load completions for each session add to your bashrc

# ~/.bashrc or ~/.profile
. <(hue-cli completion)

Usage:
  hue-cli completion [flags]

Flags:
  -h, --help   help for completion
```

And then in use:

```
(╯°□°)╯︵  hue-cli lights get --name=Stairs_<tab><tab>
Stairs_Bottom_1  Stairs_Bottom_2  Stairs_Top_1     Stairs_Top_2
```

Note, there is a special case, I had to replace space with underscore, so you can have a light collide if you name one `foo_bar` and another `foo bar` in the hue app. This seems unlikely.

As a result these are equivalent: 
- `hue-cli lights get --name=Stairs_Bottom_1`
- `hue-cli lights get --name=Stairs\ Bottom\ 1`
- `hue-cli lights get --name="Stairs Bottom 1"`
